### PR TITLE
Fix Tool.vue not being able to show closure type scheduled job

### DIFF
--- a/resources/js/components/Tool.vue
+++ b/resources/js/components/Tool.vue
@@ -81,7 +81,11 @@ export default {
     methods: {        
 
         canDispatchCommand(command) {
-            return command.includes("\Jobs")
+            if(command){
+                return command.includes("\Jobs")
+            }
+
+            return false;
         },
 
         openConfirmationModal(job) {


### PR DESCRIPTION
Fixes https://github.com/llaski/nova-scheduled-jobs/issues/7

Just need to recompile the JS and now you can see any closures type commands in the scheduler. Admittedly there's not much to see in the description, but you can at least see the schedule time and expression etc.

Have confirmed working.