### PR TITLE
resolve get_class() parameter issue

### DIFF
--- a/src/Http/Controllers/DispatchJobController.php
+++ b/src/Http/Controllers/DispatchJobController.php
@@ -20,6 +20,6 @@ class DispatchJobController
         
         $command = resolve($data['command']);
 
-        dispatch($command);
+        dispatch(new $command);
     }
 }


### PR DESCRIPTION
Resolves "get_class() expects parameter 1 to be object, string given" error