### PR TITLE
Require Nova via Composer allowing Laravel 6.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,12 @@
     "require": {
         "php": ">=7.1.0",
         "dragonmantank/cron-expression": "^2.2",
-        "illuminate/console": "^5.6|^5.7"
+        "laravel/nova": "^1.0|^2.0",
+        "illuminate/console": "^5.6|^6.0"
     },
     "require-dev": {
-        "illuminate/cache": "^5.6",
-        "orchestra/testbench": "^3.7",
-        "phpunit/phpunit": "^7.3",
-        "laravel/nova": "~1.0"
+        "illuminate/cache": "*",
+        "orchestra/testbench": "^3.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Composer version constraints updated:

* Laravel Nova added as a requirement for the better version tracking. This is better practice. See https://github.com/spatie/nova-backup-tool/blob/master/composer.json#L18-L23 for example.

* "illuminate/console" version 6.0 added, allowing support of Laravel 6.0

* "phpunit" dependency removed as a redundant one - it is already required by "orchestra/testbench"

* allow any version for dev "illuminate/*" packages as their version determined by "illuminate/console" already.