### PR TITLE
Remove deprecated helpers, fixing compatibility with Laravel 6

### DIFF
--- a/src/Schedule/Event.php
+++ b/src/Schedule/Event.php
@@ -2,6 +2,7 @@
 
 namespace Llaski\NovaScheduledJobs\Schedule;
 
+use Illuminate\Support\Arr;
 use Llaski\NovaScheduledJobs\Vendor\CronSchedule;
 
 abstract class Event
@@ -21,7 +22,7 @@ abstract class Event
     {
         try {
             $reflection = new \ReflectionClass($this->className());
-            return (string) array_get($reflection->getDefaultProperties(), 'description', '');
+            return (string) Arr::get($reflection->getDefaultProperties(), 'description', '');
         } catch (\ReflectionException $exception) {
             return '';
         }

--- a/tests/Fakes/Kernel.php
+++ b/tests/Fakes/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace Llaski\NovaScheduledJobs\Tests\Fakes;
 
+use Illuminate\Support\Arr;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
@@ -39,7 +40,7 @@ class Kernel extends ConsoleKernel
     {
         collect($this->scheduledJobs)->each(function ($job) use ($schedule) {
 
-            if (array_has($job, 'job')) {
+            if (Arr::has($job, 'job')) {
                 $command = $schedule->job($job['job']);
             } else {
                 $command = $schedule->command($job['command']);
@@ -47,7 +48,7 @@ class Kernel extends ConsoleKernel
 
             $command->{$job['schedule']}();
 
-            collect(array_get($job, 'additionalOptions', []))->each(function ($additionalOption) use ($command) {
+            collect(Arr::get($job, 'additionalOptions', []))->each(function ($additionalOption) use ($command) {
                 $command->{$additionalOption}();
             });
         });


### PR DESCRIPTION
Removes deprecated `arr_*` helpers, allowing to function with Laravel 6 without "laravel/helpers" package