### PR TITLE
Add support for Laravel Nova 3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.1.0",
         "dragonmantank/cron-expression": "^2.2",
-        "laravel/nova": "^1.0|^2.0",
+        "laravel/nova": "^1.0|^2.0|^3.0",
         "illuminate/console": "^5.6|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel Nova 3.0.0 is mostly a patch to support Laravel 7