### PR TITLE
Fix Deprecation Notice when installing package with composer v1.10+

### DIFF
--- a/src/Vendor/Tool.php
+++ b/src/Vendor/Tool.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Llaski\NovaScheduledJobs;
+namespace Llaski\NovaScheduledJobs\Vendor;
 
 use Laravel\Nova\Nova;
 use Laravel\Nova\Tool as BaseTool;


### PR DESCRIPTION
When installing the package in a Laravel project using Composer v1.10 I see the following notice in my console.

> Deprecation Notice: Class Llaski\NovaScheduledJobs\Tool located in ./vendor/llaski/nova-scheduled-jobs/src/Vendor/Tool.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/Cellar/composer/1.10.0/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:185

The problem can be fixed by updating the Namespace of `./src/Vendor/Tool.php`.

```diff
<?php

-namespace Llaski\NovaScheduledJobs;
+namespace Llaski\NovaScheduledJobs\Vendor;

use Laravel\Nova\Nova;
use Laravel\Nova\Tool as BaseTool;

class Tool extends BaseTool
```

I've cloned the repo locally, made the change and successfully ran the test suite. However, I'm not sure if I broke something else. 🤷‍♂ 

Maybe someone with more knowledge about the code base can have a look?