### PR TITLE
Laravel 8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.2.0",
         "dragonmantank/cron-expression": "^2.2",
-        "laravel/nova": "^1.0|^2.0|^3.0",
-        "illuminate/console": "^5.6|^6.0|^7.0"
+        "laravel/nova": "^2.0|^3.0",
+        "illuminate/console": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "illuminate/cache": "*",


### PR DESCRIPTION
Support for laravel 8, drop support for versions of php and laravel no longer under lts, drop support for oldest version of nova