### PR TITLE
fix InvalidArgumentException

### DIFF
--- a/src/Schedule/Event.php
+++ b/src/Schedule/Event.php
@@ -23,8 +23,10 @@ abstract class Event
         try {
             $reflection = new \ReflectionClass($this->className());
             return (string) Arr::get($reflection->getDefaultProperties(), 'description', '');
+        } catch (\InvalidArgumentException $exception) {
+            return $this->event->description;
         } catch (\ReflectionException $exception) {
-            return '';
+            return $this->event->description;
         }
     }
 

--- a/tests/Fakes/Kernel.php
+++ b/tests/Fakes/Kernel.php
@@ -42,14 +42,16 @@ class Kernel extends ConsoleKernel
 
             if (Arr::has($job, 'job')) {
                 $command = $schedule->job($job['job']);
-            } else {
+            } else if (Arr::has($job, 'command')) {
                 $command = $schedule->command($job['command']);
+            } else if (Arr::has($job, 'exec')) {
+                $command = $schedule->exec($job['exec']);
             }
 
             $command->{$job['schedule']}();
 
-            collect(Arr::get($job, 'additionalOptions', []))->each(function ($additionalOption) use ($command) {
-                $command->{$additionalOption}();
+            collect(Arr::get($job, 'additionalOptions', []))->each(function ($parameter, $additionalOption) use ($command) {
+                $command->{$additionalOption}($parameter);
             });
         });
     }

--- a/tests/ListJobsTest.php
+++ b/tests/ListJobsTest.php
@@ -34,16 +34,23 @@ class ListJobsTest extends TestCase
                     'command' => 'store-fake-metrics',
                     'schedule' => 'hourly',
                     'additionalOptions' => [
-                        'withoutOverlapping',
-                        'onOneServer',
-                        'evenInMaintenanceMode'
+                        'withoutOverlapping' => null,
+                        'onOneServer' => null,
+                        'evenInMaintenanceMode' => null
+                    ]
+                ],
+                [
+                    'exec' => 'df',
+                    'schedule' => 'hourly',
+                    'additionalOptions' => [
+                        'description' => 'Check disk usage',
                     ]
                 ],
                 [
                     'job' => UpdateOrders::class,
                     'schedule' => 'daily',
                     'additionalOptions' => [
-                        'evenInMaintenanceMode'
+                        'evenInMaintenanceMode' => null
                     ]
                 ],
             ],
@@ -67,7 +74,7 @@ class ListJobsTest extends TestCase
             ],
             [
                 'command' => 'store-fake-metrics',
-                'description' => '',
+                'description' => null,
                 'expression' => '0 * * * *',
                 'humanReadableExpression' => 'At the hour past every hour on every day.',
                 'nextRunAt' => Cron::nextRunAt('0 * * * *')->toIso8601String(),
@@ -75,6 +82,17 @@ class ListJobsTest extends TestCase
                 'withoutOverlapping' => true,
                 'onOneServer' => true,
                 'evenInMaintenanceMode' => true,
+            ],
+            [
+                'command' => null,
+                'description' => 'Check disk usage',
+                'expression' => '0 * * * *',
+                'humanReadableExpression' => 'At the hour past every hour on every day.',
+                'nextRunAt' => Cron::nextRunAt('0 * * * *')->toIso8601String(),
+                'timezone' => 'UTC',
+                'withoutOverlapping' => false,
+                'onOneServer' => false,
+                'evenInMaintenanceMode' => false,
             ],
             [
                 'command' => UpdateOrders::class,


### PR DESCRIPTION
An InvalidArgumentException is thrown when using exec in a schedule. This PR catches this exception and returns event description when an exception is thrown, instead of an empty string.