### PR TITLE
Enable authorization for this tool

### DIFF
--- a/src/Http/Middleware/Authorize.php
+++ b/src/Http/Middleware/Authorize.php
@@ -6,12 +6,19 @@ namespace Llaski\NovaScheduledJobs\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Laravel\Nova\Nova;
+use Laravel\Nova\Tool;
+use Llaski\NovaScheduledJobs\NovaScheduledJobsTool;
 use Symfony\Component\HttpFoundation\Response;
 
 class Authorize
 {
     public function handle(Request $request, Closure $next): Response
     {
-        return $next($request);
+        $tool = collect(Nova::registeredTools())->first(function(Tool $tool){
+            return $tool instanceof NovaScheduledJobsTool;
+        });
+
+        return optional($tool)->authorize($request) ? $next($request) : abort(403);
     }
 }


### PR DESCRIPTION
You should be able to restrict access to this tool. Former `Authorize` middleware bypassed any authorization check. 

See https://nova.laravel.com/docs/4.0/customization/tools.html#authorization on how to configure authorization for tools.

This change also affects the card which is part of this package as it uses routes using the `Authorize` middleware.
So if you want to use the card, make sure that it uses the same `canSee` as the tool.