### PR TITLE
Add authenticate to the API routes

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -42,7 +42,7 @@ class ServiceProvider extends IlluminateServiceProvider
         Nova::router(['nova', Authenticate::class, Authorize::class], 'nova-scheduled-jobs')
             ->group(__DIR__ . '/../routes/inertia.php');
 
-        Route::middleware(['nova', Authorize::class])
+        Route::middleware(['nova', Authenticate::class, Authorize::class])
             ->prefix('nova-vendor/nova-scheduled-jobs')
             ->group(__DIR__ . '/../routes/api.php');
     }


### PR DESCRIPTION
Currently it is possible to access the API response without being logged into Nova by accessing `/nova-vendor/nova-scheduled-jobs/jobs`

See also: https://github.com/bakerkretzmar/nova-settings-tool/pull/54
