### PR TITLE
A workaround for Laravel 10+ optimization that only loads schedules when in console

### DIFF
--- a/src/Http/Controllers/JobsController.php
+++ b/src/Http/Controllers/JobsController.php
@@ -16,13 +16,17 @@ class JobsController
      * Execute the console command.
      *
      * @param  \Illuminate\Contracts\Console\Kernel   $kernel (Not sure why we need to inject the kernel, but without it we don't get the schedueld jobs. Prob something to do with how the schedule method is called from the kernel)
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
      * @return void
      *
      * @throws \Exception
      */
-    public function __invoke(Kernel $kernel, Schedule $schedule)
+    public function __invoke(Kernel $kernel)
     {
+        // See: https://github.com/laravel/framework/issues/51369
+        $kernel->bootstrap();
+
+        $schedule = app(\Illuminate\Console\Scheduling\Schedule::class);
+
         $jobs = collect($schedule->events())->map(function ($event) {
             return EventFactory::make($event);
         });


### PR DESCRIPTION

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
